### PR TITLE
Try to have better scroll

### DIFF
--- a/src/components/CoinsPage.js
+++ b/src/components/CoinsPage.js
@@ -310,7 +310,13 @@ CoinsPage.propTypes = {
     isRTL: PropTypes.bool
   }),
   isDarkTheme: PropTypes.bool.isRequired,
-  windowSize: PropTypes.string.isRequired,
+  windowSize: PropTypes.oneOf([
+    'xs',
+    'sm',
+    'md',
+    'lg',
+    'xl'
+  ]).isRequired,
   showLoading: PropTypes.bool.isRequired
 };
 

--- a/src/components/CoinsPage.js
+++ b/src/components/CoinsPage.js
@@ -264,6 +264,8 @@ class CoinsPage extends Component {
     const leftPanelClasses = classnamesjss(classes, 'root__ToolBar__LeftPanel', `root__ToolBar__LeftPanel--${this.props.windowSize}`);
     const rightPanelClasses = classnamesjss(classes, 'root__ToolBar__RightPanel', `root__ToolBar__RightPanel--${this.props.windowSize}`);
 
+    const scrollOffset = this.props.windowSize === 'xs' ? 20 : 55;
+
     return (
       <div className={classes.root}>
         { this.renderDonations() }
@@ -282,7 +284,9 @@ class CoinsPage extends Component {
           message={ this.state.snackbarMessage }
           open={this.state.snackbarOpen}
           onClose={ () => this.setState({ snackbarOpen: false })} />
-        <CoinsTable locale={this.props.locale}
+        <CoinsTable
+          scrollOffset={scrollOffset}
+          locale={this.props.locale}
           showLoading={this.props.showLoading}
           valuePairs={this.state.displayedValuePairs} />
       </div>

--- a/src/components/CoinsTable.js
+++ b/src/components/CoinsTable.js
@@ -138,16 +138,22 @@ class CoinsTable extends Component {
     this.listeners = [];
 
     if (this.state.virtualScrollEnabled) {
-      const listenerScroll = window.addEventListener('scroll', (event) => {
-        // The bigger the factor the fewer renders will be happening
-        const changeThreshold = props.rowHeight * (this.state.scrollOffset * 0.8);
+      // The bigger the factor the fewer renders will be happening
+      const changeThreshold = props.rowHeight * (this.state.scrollOffset * 1);
 
-        if (Math.abs(event.target.scrollingElement.scrollTop - this.state.scrollTop) >= changeThreshold) {
-          this.setState({
-            scrollTop: event.target.scrollingElement.scrollTop
-          });
-        }
-      });
+      const onScroll = (event) => {
+        window.requestAnimationFrame(() => {
+          const lastKnownScrollTop = window.scrollY;
+
+          if (Math.abs(lastKnownScrollTop - this.state.scrollTop) >= changeThreshold) {
+            this.setState({
+              scrollTop: lastKnownScrollTop
+            });
+          }
+        });
+      };
+
+      const listenerScroll = window.addEventListener('scroll', onScroll);
 
       this.listeners.push({
         target: window,

--- a/src/components/CoinsTable.js
+++ b/src/components/CoinsTable.js
@@ -421,7 +421,14 @@ CoinsTable.propTypes = {
   }),
   rowHeight: PropTypes.number,
   scrollOffset: PropTypes.number,
-  virtualScrollEnabled: PropTypes.bool
+  virtualScrollEnabled: PropTypes.bool,
+  windowSize: PropTypes.oneOf([
+    'xs',
+    'sm',
+    'md',
+    'lg',
+    'xl'
+  ])
 };
 
 CoinsTable.defaultProps = {

--- a/src/components/CoinsTable.js
+++ b/src/components/CoinsTable.js
@@ -139,7 +139,7 @@ class CoinsTable extends Component {
 
     if (this.state.virtualScrollEnabled) {
       // The bigger the factor the fewer renders will be happening
-      const changeThreshold = props.rowHeight * (this.state.scrollOffset * 1);
+      const changeThreshold = props.rowHeight * (this.state.scrollOffset * 0.8);
 
       const onScroll = (event) => {
         window.requestAnimationFrame(() => {


### PR DESCRIPTION
# What this PR is all about?

* Save the window.scrollY in a variable instead of calling it twice which triggers reflow of the browser
* use of requestAnimationFrame
* moved static calculation out of the scroll event
